### PR TITLE
add user-agent header for http client requests

### DIFF
--- a/crates/pattern_core/src/data_source/bluesky.rs
+++ b/crates/pattern_core/src/data_source/bluesky.rs
@@ -375,7 +375,10 @@ impl atrium_xrpc::HttpClient for PatternHttpClient {
 impl Default for PatternHttpClient {
     fn default() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .user_agent(concat!("pattern/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .unwrap(), // panics for the same reasons Client::new() would: https://docs.rs/reqwest/latest/reqwest/struct.Client.html#panics
         }
     }
 }


### PR DESCRIPTION
the easiest single location i spotted to add it. seems like this will also get used with some atrium/xrpc client requests, but i think that's harmless at worst.

having the UA makes pattern more observeable and debuggable from (microcosm) constellation.