### PR TITLE
Claude Haiku 4.5 Support

### DIFF
--- a/crates/pattern_core/src/model.rs
+++ b/crates/pattern_core/src/model.rs
@@ -130,7 +130,7 @@ impl ResponseOptions {
             // ));
             headers.push((
                 "anthropic-beta".to_string(),
-                "code-execution-2025-05-22".to_string(),
+                "code-execution-2025-08-25".to_string(),
             ));
         }
 

--- a/crates/pattern_core/src/model/defaults.rs
+++ b/crates/pattern_core/src/model/defaults.rs
@@ -212,6 +212,28 @@ fn init_defaults() -> HashMap<&'static str, ModelDefaults> {
     );
 
     defaults.insert(
+        "claude-haiku-4-5-20251001",
+        ModelDefaults {
+            context_window: 200_000,
+            max_output_tokens: Some(64_000),
+            capabilities: vec![
+                ModelCapability::TextGeneration,
+                ModelCapability::FunctionCalling,
+                ModelCapability::CodeExecution,
+                ModelCapability::SystemPrompt,
+                ModelCapability::VisionInput,
+                ModelCapability::ComputerUse,
+                ModelCapability::TextEdit,
+                ModelCapability::WebSearch,
+                ModelCapability::LongContext,
+                ModelCapability::ExtendedThinking,
+            ],
+            cost_per_1k_prompt: Some(0.001),
+            cost_per_1k_completion: Some(0.005),
+        },
+    );
+
+    defaults.insert(
         "claude-3-5-haiku-20241022",
         ModelDefaults {
             context_window: 200_000,


### PR DESCRIPTION
Updates to allow use of Claude Haiku 4.5. Not clear to me if the beta header is still required for prompt-caching or not, so I left it as is. I think it is if you want 1 hour caching.

Update anthropic-beta header to use latest code execution tool (this is a 4.5 breaking change) and add updated model defaults.

Didn't see any other obvious places changes were required.